### PR TITLE
Fix: change wallet id key in profile settings

### DIFF
--- a/kafka_queue/events/__init__.py
+++ b/kafka_queue/events/__init__.py
@@ -48,7 +48,7 @@ async def handle_event(profile: Profile, event: EventWithMetadata):
     """Produce kafka events from aca-py events."""
 
     LOGGER.info("Handling Kafka producer event: %s", event)
-    wallet_id = cast(Optional[str], profile.settings.get("wallet_id"))
+    wallet_id = cast(Optional[str], profile.settings.get("wallet.id"))
     payload = {
         "wallet_id": wallet_id or "base",
         "state": event.payload.get("state"),


### PR DESCRIPTION
When integrating with our components I noticed the event's `wallet_id` was always defaulted to `base`.

Fix: changed access to wallet id in `profile.settings` from `wallet_id` to `wallet.id`, as found in the "old" http webhook handler.