### PR TITLE
feat: embark metadata along with the outbound message

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,17 @@ $ aca-py start \
     --plugin-config plugins-config.yaml \
     # ... the remainder of your startup arguments
 ```
+
+## Consuming DIDComm messages
+
+Messages produced by this plugin contain metadata in addition to the encrypted DIDComm message.
+Messages look like:
+```json
+{
+    "service": {"url": "recipient url"},
+    "metadata": {...},
+    "payload": "encryped_and_packed_didcomm_message"
+}
+```
+
+Be cautious and only send the `payload` content over the wire to the DIDComm recipient.

--- a/int/docker-compose.yml
+++ b/int/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
     ports:
       - 22181:2181
+
   kafka:
     image: confluentinc/cp-kafka:latest
     depends_on:
@@ -20,6 +21,7 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
   restproxy:
     image: confluentinc/cp-kafka-rest
     restart: always
@@ -57,6 +59,7 @@ services:
       - WAIT_SLEEP_INTERVAL=1
       - WAIT_HOST_CONNECT_TIMEOUT=60
     depends_on:
+      - zookeeper
       - kafka
 
   deliverer:
@@ -73,6 +76,9 @@ services:
       - WAIT_HOSTS_TIMEOUT=120
       - WAIT_SLEEP_INTERVAL=1
       - WAIT_HOST_CONNECT_TIMEOUT=60
+    depends_on:
+      - zookeeper
+      - kafka
 
   echo:
     image: dbluhm/echo-agent:6c22a88
@@ -96,7 +102,16 @@ services:
       - restproxy
       - relay
       - deliverer
-    command: start -it kafka_queue.inbound kafka 0 -ot kafka_queue.outbound -e http://relay:80 --no-ledger --admin 0.0.0.0 3001 --admin-insecure-mode --plugin kafka_queue.events --log-level debug
+    command: >
+      start
+      -it kafka_queue.inbound kafka 0
+      -ot kafka_queue.outbound
+      -e http://relay:80
+      --no-ledger
+      --admin 0.0.0.0 3001
+      --admin-insecure-mode
+      --plugin kafka_queue.events
+      --log-level debug
     environment:
       - WAIT_BEFORE_HOSTS=5
       - WAIT_HOSTS=zookeeper:2181,kafka:9092,restproxy:8086,relay:80
@@ -119,7 +134,7 @@ services:
         - WAIT_BEFORE_HOSTS=6
         - WAIT_HOSTS=zookeeper:2181, kafka:9092, restproxy:8086, agent:3001, echo:3002
         - WAIT_HOSTS_TIMEOUT=120
-        - WAIT_SLEEP_INTERVAL=1
+        - WAIT_SLEEP_INTERVAL=3
         - WAIT_HOST_CONNECT_TIMEOUT=60
         - AGENT_HOST=agent
         - AGENT_PORT=3000
@@ -128,5 +143,6 @@ services:
       depends_on:
         - zookeeper
         - kafka
+        - restproxy
         - agent
         - echo

--- a/kafka_queue/outbound.py
+++ b/kafka_queue/outbound.py
@@ -12,6 +12,8 @@ from aries_cloudagent.transport.outbound.base import (
     BaseOutboundTransport,
     OutboundTransportError,
 )
+from aries_cloudagent.transport.outbound.manager import QueuedOutboundMessage
+
 from .config import get_config, OutboundConfig
 
 LOGGER = logging.getLogger(__name__)
@@ -89,7 +91,7 @@ class KafkaOutboundQueue(BaseOutboundTransport):
     async def handle_message(
         self,
         profile: Profile,
-        payload: Union[str, bytes],
+        outbound_message: QueuedOutboundMessage,
         endpoint: str,
         metadata: dict = None,
     ):
@@ -99,24 +101,33 @@ class KafkaOutboundQueue(BaseOutboundTransport):
         if not endpoint:
             raise OutboundTransportError("No endpoint provided")
 
-        message = str.encode(
-            json.dumps(
-                {
-                    "service": {"url": endpoint},
-                    "payload": base64.urlsafe_b64encode(payload).decode(),
-                }
-            ),
+        message_dict = {
+            "service": {"url": endpoint},
+            "metadata": {
+                "wallet_id": profile.settings.get("wallet.id"),
+                "connection_id": outbound_message.message.connection_id,
+                "message": outbound_message.message.payload,
+            },
+            "payload": base64.urlsafe_b64encode(outbound_message.payload).decode(),
+        }
+        json_message = str.encode(
+            json.dumps(message_dict),
         )
+
         topic = self.config.topic
-        partition_key = ",".join(_recipients_from_packed_message(payload)).encode()
+        partition_key = ",".join(
+            _recipients_from_packed_message(outbound_message.payload)
+        ).encode()
 
         try:
             LOGGER.info(
                 "  - Producing message for kafka: (%s)[%s]: %s",
                 topic,
                 partition_key,
-                message,
+                json_message,
             )
-            return await self.producer.send_and_wait(topic, message, key=partition_key)
+            return await self.producer.send_and_wait(
+                topic, json_message, key=partition_key
+            )
         except Exception:
             LOGGER.exception("Error while pushing to kafka")

--- a/kafka_queue/outbound.py
+++ b/kafka_queue/outbound.py
@@ -10,6 +10,7 @@ from aiokafka.producer.producer import AIOKafkaProducer
 from aries_cloudagent.core.profile import Profile
 from aries_cloudagent.transport.outbound.base import (
     BaseOutboundTransport,
+    BaseWireFormat,
     OutboundTransportError,
 )
 from aries_cloudagent.transport.outbound.manager import QueuedOutboundMessage
@@ -56,9 +57,13 @@ class KafkaOutboundQueue(BaseOutboundTransport):
     schemes = ("kafka",)
     is_external = True
 
-    def __init__(self, root_profile: Profile):
+    def __init__(
+        self,
+        wire_format: Optional[BaseWireFormat] = None,
+        root_profile: Optional[Profile] = None,
+    ):
         """Initialize base queue type."""
-        super().__init__(root_profile=root_profile)
+        super().__init__(wire_format=wire_format, root_profile=root_profile)
         LOGGER.info(get_config(root_profile.settings))
 
         self.config = (


### PR DESCRIPTION
For business controller's convenience, metadata comprise of the target connection's connection_id, sender wallet id and full didcomm message.

This is bound to the changes of https://github.com/sicpa-dlab/aries-cloudagent-python/commit/7deadc8b077249ea55767e2c1d4b24cfb693632a